### PR TITLE
Disabling exchange rate module

### DIFF
--- a/discount-calculator-web/src/app/sheet/sheet.component.html
+++ b/discount-calculator-web/src/app/sheet/sheet.component.html
@@ -78,9 +78,11 @@
                         <input class="form-control" type="text" [attr.value]="txtTotal | number:'1.0-3'"
                             disabled /></div>
                 </div>
-                <div class="row card-body">
+                <!--
+		<div class="row card-body">
                     <app-exchange-rate [fromCurrencyAmount]="txtTotal"></app-exchange-rate>
                 </div>
+		-->
             </div>
         </div>
     </div>


### PR DESCRIPTION
Exchange rate API free tier only allows http calls but the app runs in https,
therefore disabling exchange rate module